### PR TITLE
feat: 편지 자세히보기 페이지, 파티룸 슬라이더

### DIFF
--- a/rememb/package.json
+++ b/rememb/package.json
@@ -15,10 +15,13 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.4.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "react-kakao-login": "^2.1.0",
     "react-modal": "^3.15.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.29.0",
+    "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
   },

--- a/rememb/src/App.js
+++ b/rememb/src/App.js
@@ -13,6 +13,7 @@ import Pang from './pages/YourHome/Letter/Pang';
 import Setting from './pages/Tutorial/Setting';
 import './style.css';
 import './style1.css';
+import LetterContent from './pages/MyHome/LetterContent';
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
       <Route path="/myParty" element={<Home />}></Route>
       <Route path="/myParty/ansBalance" element={<AnswerBalance />}></Route>
       <Route path="/myParty/seeBalance" element={<SeeBalance />}></Route>
+      <Route path="/lettercontent" element={<LetterContent/>}></Route>
       {/* 남의 페이지 볼 때 */}
       <Route path="/others" element={<YourHome />}></Route>`
       <Route path="/others/selectimg" element={<SelectImg />}></Route>

--- a/rememb/src/components/CommonHome/PartyRoom.js
+++ b/rememb/src/components/CommonHome/PartyRoom.js
@@ -1,5 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
+import "slick-carousel/slick/slick.css";
+import Slider from "react-slick";
+import {BiChevronLeft,BiChevronRight} from "react-icons/bi";
+import { useNavigate } from "react-router-dom";
 
 const BackImg=styled.div`
   margin: 7rem 10rem;
@@ -7,15 +11,131 @@ const BackImg=styled.div`
   background-color: #FFEFF3;
   border-radius: 30px;
   height:50vh;
-/* backgro0und-image: url('/img/background.png'); */
-  /* background-repeat: no-repeat; */
-  /* background-size: 100% 100%; */
+  display: grid;
+  grid-template-columns: repeat(auto-fill,15rem);
+  grid-gap: 5vh 1rem; 
+  
+  align-items: center; /* 수직 가운데 정렬 */
+  justify-content: space-between; /* 수평 가운데 정렬 */
+  `;
+const Each=styled.div`
+  width: 15rem;
+  height: 15rem;
+
+`;
+const Img=styled.img`
+  width: 15rem;
+  height: 15rem;
+`;
+const DivPre = styled.div`
+  position: absolute;
+  left: 0rem;
+  top:45%;
+  z-index: 99;  
+`;
+const Div = styled.div`
+  position: absolute;
+  right: 10rem;
+  top:45%;
+  z-index: 99;
 `;
 const PartyRoom = () => {
+  const navi=useNavigate();
+  // const [img,setImg]=useState();
+  const onImgClick=(e)=>{
+    navi('/lettercontent',{state:{img:e},});
+  }
+  const gift=[
+    '/img/emoticons/1/1.png','/img/emoticons/1/2.png','/img/emoticons/1/3.png',
+    '/img/emoticons/2/1.png','/img/emoticons/2/2.png','/img/emoticons/2/3.png',
+    '/img/emoticons/3/1.png','/img/emoticons/3/2.png','/img/emoticons/3/3.png',
+    '/img/emoticons/0/0.png','/img/emoticons/0/1.png','/img/emoticons/0/2.png',
+    '/img/emoticons/3/1.png','/img/emoticons/3/2.png','/img/emoticons/3/3.png','/img/emoticons/3/1.png','/img/emoticons/3/2.png','/img/emoticons/3/3.png'];
+  const settings = {
+    dots: false,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: true,
+    nextArrow: (
+      <Div >
+        <BiChevronRight style={{color:'pink',position:'absolute',width:'10rem',height:'10rem'}}/>
+      </Div>
+    ),
+    prevArrow: (
+      <DivPre>
+        <BiChevronLeft style={{color:'pink',position:'absolute',width:'10rem',height:'10rem'}}/>
+      </DivPre>
+    ),
+  };
   return (
-    <BackImg>
-      여기는 파티룸 컴포넌트 공간입니다.
-    </BackImg>
+    <Slider style={{position:'relative'}} {...settings}>
+      <>
+      <BackImg>      
+        {gift.map((index)=>(
+            <>
+              <Each
+                onClick={()=>onImgClick(index)} >
+                <Img 
+                  src={index} 
+                  alt='gift' 
+                />
+                <span>유진</span>
+              </Each>
+            </>          
+        ))}
+      </BackImg>
+      </>
+      <>
+      <BackImg>      
+        {gift.map((index)=>(
+            <>
+              <Each
+                onClick={()=>onImgClick(index)} >
+                <Img 
+                  src={index} 
+                  alt='gift' 
+                />
+                <span>유진</span>
+              </Each>
+            </>          
+        ))}
+      </BackImg>
+      </>
+      <>
+      <BackImg>      
+        {gift.map((index)=>(
+            <>
+              <Each
+                onClick={()=>onImgClick(index)} >
+                <Img 
+                  src={index} 
+                  alt='gift' 
+                />
+                <span>유진</span>
+              </Each>
+            </>          
+        ))}
+      </BackImg>
+      </>
+      <>
+      <BackImg>      
+        {gift.map((index)=>(
+            <>
+              <Each
+                onClick={()=>onImgClick(index)} >
+                <Img 
+                  src={index} 
+                  alt='gift' 
+                />
+                <span>유진</span>
+              </Each>
+            </>          
+        ))}
+      </BackImg>
+      </>
+    </Slider>
   );
 };
 

--- a/rememb/src/components/Etc/SeeRP.js
+++ b/rememb/src/components/Etc/SeeRP.js
@@ -77,9 +77,7 @@ const SeeRP = () => {
                 ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ
               </Content>
             </Each>
-          </>
-          
-          
+          </>          
         ))}
       </Paper>
     </>

--- a/rememb/src/pages/MyHome/LetterContent.js
+++ b/rememb/src/pages/MyHome/LetterContent.js
@@ -1,0 +1,65 @@
+import React from "react";
+import EtcLayout from "../../components/CommonHome/EtcLayout";
+import styled from "styled-components";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Btn,BtnImg } from "../../components/CommonHome/CircleBtn";
+
+const Letterback=styled.div`
+  margin: 7rem 10rem;
+  position:relative;
+  padding: 5rem;
+  background-color: #FFEFF3;
+  border-radius: 30px;
+  height:50vh;
+  background-color: #FFEFF3;
+`;
+const Content=styled.div`
+  padding-top: 1rem;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 4rem;
+  height: fit-content;
+`;
+const From=styled.div`
+  position: absolute;
+  bottom:3rem;
+  right: 3rem;
+  width: 17rem;
+  padding:1rem 3rem;
+  width: fit-content;
+  border:none;
+  outline: none;
+  text-align: center;
+  font-size: 4.5rem;
+  border-radius: 80px;
+  background-color:#FFC1CC;
+`;
+const LetterContent=({img})=>{
+    const navi= useNavigate();
+    const location = useLocation();
+    img=location.state.img;
+    const onBtnClick=()=>{
+        navi('/myParty');
+    }
+    return(
+        <EtcLayout>
+            <Letterback>
+                <img alt="선택한 일러스트" style={{float:'left',width:'20rem', height:'20rem', margin:'0 3rem 0 0',padding:'10px',borderRadius:'20px',backgroundColor:'white'}} src={img}/>
+                <Content>
+                    To. 멋사에게<br/>
+                    안녕 멋사야 나는 두영이야
+                    너의 생일을 진심으로 축하해 
+                    어쩌구저쩌구 블라블라블라블라블라블라숑숑 블라블라숑숑블라블라숑숑
+                    어쩌구저쩌구 블라블라 숑숑블라블라 숑숑블라블라숑숑
+                </Content>
+                <From>From. 유진</From>           
+            </Letterback>
+            <Btn onClick={onBtnClick} style={{top:'72vh',left:'80rem'}}>
+                <BtnImg src="/img/home.png" alt="homeBtn"/>
+            </Btn>
+        </EtcLayout>
+    );
+};
+
+export default LetterContent;

--- a/rememb/src/pages/YourHome/Letter/WriteLetter.js
+++ b/rememb/src/pages/YourHome/Letter/WriteLetter.js
@@ -70,6 +70,8 @@ const Max=styled.span`
   position: absolute;
   bottom:15rem;
   right: 5rem;
+  font-size: 3rem;
+  color:gray;
   /* background-color: white; */
   /* padding:1rem; */
   /* border-radius: 10px; */
@@ -129,7 +131,7 @@ const WriteLetter = ({whichimg}) => {
     const img='/img/emoticons/'+whichimg[0]+'/'+whichimg[1]+'.png'
   return (
     <Layout>
-        <Letterback h='50vh'>
+        <Letterback>
         <img alt="선택한 일러스트" style={{float:'left',width:'20rem', height:'20rem', margin:'0 3rem 0 0',padding:'10px',borderRadius:'20px',backgroundColor:'white'}} src={img}/>
             <LetterTo>To. 멋사</LetterTo>
             <LetterInput


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #55 

## ✨ 주요 변경 사항
<!-- 변경 사항에 대한 설명을 적어주세요 -->
- 파티룸에 그리드 레이아웃 적용하고 선물 컴포넌트들 추가
- carousel 적용해서 선물 컴포넌트 여러개일때 슬라이드 넘기기 구현
- 각각 선물 컴포넌트 누르면 편지 내용 자세히보기 페이지로

## 📚 코드리뷰어에게 언급해야할 요소들 (선택)
<!-- 참고할 사항이 있다면 적어주세요 -->
- npm 할게 많은데,, 넘 졸려서 낼 가서 알려줄게유 ,,,,, 나 코드라이언은 못들엇숴 흑흑..

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
| `파티룸 carousel 적용` | `편지 자세히보기 페이지`| 
|:------:|:------:|
|![image](https://user-images.githubusercontent.com/91943160/184549186-0aa8acf0-0a75-4308-9160-620d3040971e.png)|![image](https://user-images.githubusercontent.com/91943160/184549218-1585ab18-f990-4dcd-96be-4d6b70513715.png)|


